### PR TITLE
Included new goals regex-property and timestamp-property in mapping

### DIFF
--- a/org.sonatype.m2e.buildhelper/lifecycle-mapping-metadata.xml
+++ b/org.sonatype.m2e.buildhelper/lifecycle-mapping-metadata.xml
@@ -13,6 +13,8 @@
           <goal>add-test-resource</goal>
           <goal>maven-version</goal>
           <goal>parse-version</goal>
+          <goal>regex-property</goal>
+          <goal>timestamp-property</goal>
         </goals>
       </pluginExecutionFilter>
       <action>


### PR DESCRIPTION
These goals were added in plugin version 1.7 and are similar in nature to `parse-version`, I assume their absence from the mapping is unintentional.
